### PR TITLE
Include user specified themes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,32 +3,26 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		},
-		{
-			"name": "Extension Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "build"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+      ],
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "preLaunchTask": "test"
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,35 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
-			"presentation": {
-				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "npm",
+      "script": "compile",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "test",
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "always"
+      },
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,12 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/chai": {
+			"version": "4.2.15",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz",
+			"integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==",
+			"dev": true
+		},
 		"@types/glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -367,6 +373,12 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
+		},
 		"astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -456,6 +468,20 @@
 			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 			"dev": true
 		},
+		"chai": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
+			"integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
+			"dev": true,
+			"requires": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
+			}
+		},
 		"chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -515,6 +541,12 @@
 					}
 				}
 			}
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "3.5.1",
@@ -595,6 +627,15 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
 			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
 			"dev": true
+		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "^4.0.0"
+			}
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -956,6 +997,12 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
 		"glob": {
@@ -1433,6 +1480,12 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
 		},
+		"pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true
+		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -1786,6 +1839,12 @@
 			"requires": {
 				"prelude-ls": "^1.2.1"
 			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-fest": {
 			"version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "chameleon",
-	"version": "0.0.1",
+	"name": "vscode-chameleon",
+	"version": "0.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "chameleon.themes": {
           "type": "array",
           "default": [],
-          "description": "Specifies the preferred color themes to loop through"
+          "description": "Specifies the preferred color themes to switch to"
         }
       }
     }
@@ -57,12 +57,14 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.12",
+    "@types/chai": "^4.2.15",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.11.7",
     "@types/vscode": "^1.53.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
+    "chai": "^4.3.0",
     "eslint": "^7.19.0",
     "glob": "^7.1.6",
     "mocha": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
       "title": "Chameleon",
       "type": "object",
       "properties": {
-        "chameleon.themes": {
+        "chameleon.exclude.themes": {
           "type": "array",
           "default": [],
-          "description": "Specifies the preferred color themes to switch to"
+          "description": "Specify the color themes to exclude"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,18 @@
         "command": "chameleon.switchLook",
         "title": "Chameleon: Switch to another look"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Chameleon",
+      "type": "object",
+      "properties": {
+        "chameleon.themes": {
+          "type": "array",
+          "default": [],
+          "description": "Specifies the preferred color themes to loop through"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/IThemes.ts
+++ b/src/IThemes.ts
@@ -1,0 +1,10 @@
+export interface IColorThemes {
+  label: string;
+  uiTheme: string;
+  id?: string;
+}
+
+export interface IIconThemes {
+  label: string;
+  id: string;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,21 +1,11 @@
 import * as vscode from "vscode";
+import { getColorThemes } from "./getColorThemes";
+import { IIconThemes } from "./IThemes";
 
 function switchLook() {
   const userConfig = vscode.workspace.getConfiguration();
 
-  const colorThemes: {
-    label: string;
-    uiTheme: string;
-    id?: string;
-  }[] = vscode.extensions.all
-    .map((ext) => ext.packageJSON.contributes?.themes || [])
-    .reduce(
-      (allColorThemes, packageColorThemes) => [
-        ...allColorThemes,
-        ...packageColorThemes,
-      ],
-      []
-    );
+  const colorThemes = getColorThemes();
   const colorTheme =
     colorThemes[Math.floor(Math.random() * colorThemes.length)];
   userConfig.update(
@@ -28,27 +18,25 @@ function switchLook() {
   if (fonts) {
     const font = fonts
       .split(",")
-      .map((f) => f.trim())
+      .map(f => f.trim())
       .sort(() => 0.5 - Math.random())
       .join(", ");
     userConfig.update("editor.fontFamily", font, true);
   }
 
-  const productIconThemes: {
-    label: string;
-    id: string;
-  }[] = [
+  const productIconThemes: IIconThemes[] = [
     { label: "Default", id: "Default" },
     ...vscode.extensions.all
-      .map((ext) => ext.packageJSON.contributes?.productIconThemes || [])
+      .map(ext => ext.packageJSON.contributes?.productIconThemes || [])
       .reduce(
         (allProductIcons, packageIcons) => [
           ...allProductIcons,
-          ...packageIcons,
+          ...packageIcons
         ],
         []
-      ),
+      )
   ];
+
   const productIconTheme =
     productIconThemes[Math.floor(Math.random() * productIconThemes.length)];
   userConfig.update(
@@ -57,11 +45,8 @@ function switchLook() {
     true
   );
 
-  const iconThemes: {
-    label: string;
-    id: string;
-  }[] = vscode.extensions.all
-    .map((ext) => ext.packageJSON.contributes?.iconThemes || [])
+  const iconThemes: IIconThemes[] = vscode.extensions.all
+    .map(ext => ext.packageJSON.contributes?.iconThemes || [])
     .reduce((allIcons, packageIcons) => [...allIcons, ...packageIcons], []);
   const iconTheme = iconThemes[Math.floor(Math.random() * iconThemes.length)];
   userConfig.update(
@@ -76,6 +61,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("chameleon.switchLook", () => {
+      switchLook();
+    }),
+
+    vscode.workspace.onDidChangeConfiguration(event => {
+      if (!event.affectsConfiguration("chameleon")) {
+        return;
+      }
       switchLook();
     })
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,10 +65,10 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     vscode.workspace.onDidChangeConfiguration(event => {
-      if (!event.affectsConfiguration("chameleon")) {
-        return;
+      if (event.affectsConfiguration("chameleon")) {
+        switchLook();
       }
-      switchLook();
+      return;
     })
   );
 }

--- a/src/getColorThemes.ts
+++ b/src/getColorThemes.ts
@@ -2,9 +2,9 @@ import { workspace, extensions } from "vscode";
 import { IColorThemes } from "./IThemes";
 
 export function getColorThemes(): IColorThemes[] {
-  const colorThemes: string[] | undefined = workspace
+  const excludedThemes: string[] | undefined = workspace
     .getConfiguration("chameleon")
-    .get("themes");
+    .get("exclude.themes");
 
   const allColorThemes: IColorThemes[] = extensions.all
     .map(ext => ext.packageJSON.contributes?.themes || [])
@@ -16,7 +16,9 @@ export function getColorThemes(): IColorThemes[] {
       []
     );
 
-  return colorThemes && colorThemes.length !== 0
-    ? allColorThemes.filter(themes => colorThemes.indexOf(themes.label) >= 0)
+  return excludedThemes && excludedThemes.length !== 0
+    ? allColorThemes.filter(
+        themes => excludedThemes.indexOf(themes.label) === -1
+      )
     : allColorThemes;
 }

--- a/src/getColorThemes.ts
+++ b/src/getColorThemes.ts
@@ -1,0 +1,22 @@
+import { workspace, extensions } from "vscode";
+import { IColorThemes } from "./IThemes";
+
+export function getColorThemes(): IColorThemes[] {
+  const colorThemes: string[] | undefined = workspace
+    .getConfiguration("chameleon")
+    .get("themes");
+
+  const allColorThemes: IColorThemes[] = extensions.all
+    .map(ext => ext.packageJSON.contributes?.themes || [])
+    .reduce(
+      (allColorThemes, packageColorTheme) => [
+        ...allColorThemes,
+        ...packageColorTheme
+      ],
+      []
+    );
+
+  return colorThemes && colorThemes.length !== 0
+    ? allColorThemes.filter(themes => colorThemes.indexOf(themes.label) >= 0)
+    : allColorThemes;
+}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,23 +1,23 @@
-import * as path from 'path';
+import * as path from "path";
 
-import { runTests } from 'vscode-test';
+import { runTests } from "vscode-test";
 
 async function main() {
-	try {
-		// The folder containing the Extension Manifest package.json
-		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../../");
 
-		// The path to test runner
-		// Passed to --extensionTestsPath
-		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+    // The path to test runner
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, "./suite");
 
-		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
-	} catch (err) {
-		console.error('Failed to run tests');
-		process.exit(1);
-	}
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  } catch (err) {
+    console.error("Failed to run tests");
+    process.exit(1);
+  }
 }
 
 main();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,10 +17,11 @@ describe("vscode-chameleon extension tests", () => {
 
   it("should be activated", function () {
     this.timeout(1 * 60 * 1000);
-    const ext = vscode.extensions.getExtension("timdeschryver.vscode-chameleon")
-      ?.isActive;
+    const isActive = vscode.extensions.getExtension(
+      "timdeschryver.vscode-chameleon"
+    )?.isActive;
 
-    expect(ext).to.be.true;
+    expect(isActive).to.be.true;
   });
 
   it("should register all chameleon commands", async () => {
@@ -33,6 +34,6 @@ describe("vscode-chameleon extension tests", () => {
   });
 
   it("should allow users to define themes to switch to", () =>
-    expect(vscode.workspace.getConfiguration("chameleon").has("themes")).to.be
-      .true);
+    expect(vscode.workspace.getConfiguration("chameleon").has("exclude.themes"))
+      .to.be.true);
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,38 @@
-import * as assert from 'assert';
+import { expect } from "chai";
+import { describe, it, before } from "mocha";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 // import * as myExtension from '../../extension';
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+describe("vscode-chameleon extension tests", () => {
+  before(() => {
+    vscode.window.showInformationMessage("Start all tests.");
+  });
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  it("should be present", () =>
+    expect(vscode.extensions.getExtension("timdeschryver.vscode-chameleon")).to
+      .be.ok);
+
+  it("should be activated", function () {
+    this.timeout(1 * 60 * 1000);
+    const ext = vscode.extensions.getExtension("timdeschryver.vscode-chameleon")
+      ?.isActive;
+
+    expect(ext).to.be.true;
+  });
+
+  it("should register all chameleon commands", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    const COMMANDS = ["vscode-chameleon.switchLook"];
+    const foundChameleonCommands = commands.filter(
+      value => COMMANDS.indexOf(value) >= 0 || value.startsWith("chameleon.")
+    );
+    expect(foundChameleonCommands.length).to.deep.equal(COMMANDS.length);
+  });
+
+  it("should allow users to define themes to switch to", () =>
+    expect(vscode.workspace.getConfiguration("chameleon").has("themes")).to.be
+      .true);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,16 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "es6",
-		"outDir": "out",
-		"lib": [
-			"es6"
-		],
-		"sourceMap": true,
-		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
-		/* Additional Checks */
-		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	},
-	"exclude": [
-		"node_modules",
-		".vscode-test",
-		"src/test"
-	]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "out",
+    "lib": ["es6"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true /* enable all strict type-checking options */
+    /* Additional Checks */
+    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+  },
+  "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
<h4>I added a feature that allows users specify which themes chameleon should switch through (VS Code has a lot of default 'ugly' themes so users may want to specify which themes chameleon can switch through rather than all available themes).</h4>

---

I also added some important tests for the extension and separated build task from test task (in tasks.json and launch.json).